### PR TITLE
fix: stabilize macOS playback and audio volume

### DIFF
--- a/src/mainwid.cpp
+++ b/src/mainwid.cpp
@@ -219,8 +219,14 @@ bool MainWid::ConnectSignalSlots()
     connect(VideoCtl::GetInstance(), &VideoCtl::SigStopFinished, ui->CtrlBarWid, &CtrlBar::OnStopFinished, Qt::QueuedConnection);
     connect(VideoCtl::GetInstance(), &VideoCtl::SigStopFinished, ui->ShowWid, &Show::OnStopFinished, Qt::QueuedConnection);
     connect(VideoCtl::GetInstance(), &VideoCtl::SigFrameDimensionsChanged, ui->ShowWid, &Show::OnFrameDimensionsChanged, Qt::QueuedConnection);
+    connect(VideoCtl::GetInstance(), &VideoCtl::SigVideoFrame, ui->ShowWid, &Show::OnVideoFrame, Qt::QueuedConnection);
     connect(VideoCtl::GetInstance(), &VideoCtl::SigStopFinished, &m_stTitle, &Title::OnStopFinished, Qt::DirectConnection);
     connect(VideoCtl::GetInstance(), &VideoCtl::SigStartPlay, &m_stTitle, &Title::OnPlay, Qt::DirectConnection);
+    connect(VideoCtl::GetInstance(), &VideoCtl::SigStartPlay, this, [this](const QString &) {
+        ui->CtrlBarWid->raise();
+        ui->PlaylistWid->raise();
+        ui->TitleWid->raise();
+    }, Qt::QueuedConnection);
 
     connect(&m_stCtrlBarAnimationTimer, &QTimer::timeout, this, &MainWid::OnCtrlBarAnimationTimeOut);
 

--- a/src/show.cpp
+++ b/src/show.cpp
@@ -12,6 +12,7 @@
 
 #include <QDebug>
 #include <QMutex>
+#include <QPainter>
 
 #include "show.h"
 #include "ui_show.h"
@@ -69,12 +70,19 @@ bool Show::Init()
         return false;
     }
 
-	//ui->label->setUpdatesEnabled(false);
+#if defined(__APPLE__)
+    setFocusPolicy(Qt::StrongFocus);
+#else
+    setAttribute(Qt::WA_NativeWindow);
+    setAttribute(Qt::WA_DontCreateNativeAncestors);
+    setFocusPolicy(Qt::StrongFocus);
+    winId();
+#endif
+#if defined(__APPLE__)
+    ui->label->hide();
+#endif
 
-
-
-
-	return true;
+    return true;
 }
 
 void Show::OnFrameDimensionsChanged(int nFrameWidth, int nFrameHeight)
@@ -86,8 +94,24 @@ void Show::OnFrameDimensionsChanged(int nFrameWidth, int nFrameHeight)
     ChangeShow();
 }
 
+void Show::OnVideoFrame(const QImage &frame)
+{
+#if defined(__APPLE__)
+    {
+        QMutexLocker locker(&m_frameMutex);
+        m_frame = frame;
+    }
+    update();
+#else
+    Q_UNUSED(frame);
+#endif
+}
+
 void Show::ChangeShow()
 {
+#if defined(__APPLE__)
+    return;
+#endif
     g_show_rect_mutex.lock();
 
     if (m_nLastFrameWidth == 0 && m_nLastFrameHeight == 0)
@@ -120,6 +144,22 @@ void Show::ChangeShow()
     g_show_rect_mutex.unlock();
 }
 
+QRect Show::CalcAspectRect(const QSize &srcSize, const QRect &dstRect) const
+{
+    if (srcSize.isEmpty())
+        return dstRect;
+    const double srcAspect = static_cast<double>(srcSize.width()) / static_cast<double>(srcSize.height());
+    int w = dstRect.width();
+    int h = static_cast<int>(w / srcAspect);
+    if (h > dstRect.height()) {
+        h = dstRect.height();
+        w = static_cast<int>(h * srcAspect);
+    }
+    const int x = dstRect.x() + (dstRect.width() - w) / 2;
+    const int y = dstRect.y() + (dstRect.height() - h) / 2;
+    return QRect(x, y, w, h);
+}
+
 void Show::dragEnterEvent(QDragEnterEvent *event)
 {
 //    if(event->mimeData()->hasFormat("text/uri-list"))
@@ -134,6 +174,20 @@ void Show::resizeEvent(QResizeEvent *event)
     Q_UNUSED(event);
 
     ChangeShow();
+}
+
+void Show::paintEvent(QPaintEvent *event)
+{
+    QWidget::paintEvent(event);
+#if defined(__APPLE__)
+    QPainter painter(this);
+    painter.fillRect(rect(), Qt::black);
+    QMutexLocker locker(&m_frameMutex);
+    if (!m_frame.isNull()) {
+        QRect target = CalcAspectRect(m_frame.size(), rect());
+        painter.drawImage(target, m_frame);
+    }
+#endif
 }
 
 void Show::keyReleaseEvent(QKeyEvent *event)
@@ -189,11 +243,24 @@ void Show::OnDisplayMsg(QString strMsg)
 
 void Show::OnPlay(QString strFile)
 {
-    VideoCtl::GetInstance()->StartPlay(strFile, ui->label->winId());
+    setFocus(Qt::OtherFocusReason);
+#if !defined(__APPLE__)
+    ui->label->hide();
+#endif
+    VideoCtl::GetInstance()->StartPlay(strFile, winId());
 }
 
 void Show::OnStopFinished()
 {
+#if !defined(__APPLE__)
+    ui->label->show();
+#endif
+#if defined(__APPLE__)
+    {
+        QMutexLocker locker(&m_frameMutex);
+        m_frame = QImage();
+    }
+#endif
     update();
 }
 

--- a/src/show.h
+++ b/src/show.h
@@ -20,6 +20,8 @@
 #include <QMenu>
 #include <QActionGroup>
 #include <QAction>
+#include <QImage>
+#include <QMutex>
 
 #include "videoctl.h"
 
@@ -61,6 +63,7 @@ protected:
      * @note
      */
     void resizeEvent(QResizeEvent *event);
+    void paintEvent(QPaintEvent *event);
 
     /**
      * @brief	按键事件
@@ -93,6 +96,7 @@ public:
      * @note
      */
     void OnFrameDimensionsChanged(int nFrameWidth, int nFrameHeight);
+    void OnVideoFrame(const QImage &frame);
 private:
 	/**
 	 * @brief	显示信息
@@ -114,6 +118,11 @@ private:
 
 
     void ChangeShow();
+
+    QRect CalcAspectRect(const QSize &srcSize, const QRect &dstRect) const;
+
+    QImage m_frame;
+    QMutex m_frameMutex;
 signals:
     void SigOpenFile(QString strFileName);///< 增加视频文件
 	void SigPlay(QString strFile); ///<播放

--- a/src/videoctl.cpp
+++ b/src/videoctl.cpp
@@ -11,6 +11,7 @@
 
 
 #include <QDebug>
+#include <QMetaObject>
 #include <QMutex>
 
 #include <thread>
@@ -122,9 +123,55 @@ int VideoCtl::upload_texture(SDL_Texture *tex, AVFrame *frame, struct SwsContext
     return ret;
 }
 
+QImage VideoCtl::frame_to_image(AVFrame *frame, struct SwsContext **img_convert_ctx)
+{
+    if (frame == nullptr)
+        return QImage();
+    const int w = frame->width;
+    const int h = frame->height;
+    QImage image(w, h, QImage::Format_ARGB32);
+    if (image.isNull())
+        return QImage();
+
+    *img_convert_ctx = sws_getCachedContext(*img_convert_ctx,
+        w, h, (AVPixelFormat)frame->format,
+        w, h, AV_PIX_FMT_BGRA,
+        SWS_BICUBIC, NULL, NULL, NULL);
+    if (*img_convert_ctx == NULL) {
+        av_log(NULL, AV_LOG_FATAL, "Cannot initialize the conversion context\n");
+        return QImage();
+    }
+
+    uint8_t *dst_data[4] = { image.bits(), NULL, NULL, NULL };
+    int dst_linesize[4] = { static_cast<int>(image.bytesPerLine()), 0, 0, 0 };
+    sws_scale(*img_convert_ctx, (const uint8_t * const *)frame->data, frame->linesize,
+        0, h, dst_data, dst_linesize);
+
+    return image;
+}
+
 //显示视频画面
 void VideoCtl::video_image_display(VideoState *is)
 {
+#if defined(__APPLE__)
+    if (frame_queue_nb_remaining(&is->pictq) <= 0)
+        return;
+    Frame *vp = frame_queue_peek_last(&is->pictq);
+    if (vp && vp->frame &&
+        vp->frame->width > 0 && vp->frame->height > 0 &&
+        vp->frame->data[0] != NULL && vp->frame->linesize[0] > 0) {
+        if (m_nFrameW != vp->frame->width || m_nFrameH != vp->frame->height)
+        {
+            m_nFrameW = vp->frame->width;
+            m_nFrameH = vp->frame->height;
+            emit SigFrameDimensionsChanged(m_nFrameW, m_nFrameH);
+        }
+        QImage img = frame_to_image(vp->frame, &is->img_convert_ctx);
+        if (!img.isNull())
+            emit SigVideoFrame(img);
+    }
+    return;
+#else
     Frame *vp;
     Frame *sp = NULL;
     SDL_Rect rect;
@@ -200,6 +247,7 @@ void VideoCtl::video_image_display(VideoState *is)
     if (sp) {
         SDL_RenderCopy(renderer, is->sub_texture, NULL, &rect);
     }
+#endif
 }
 
 
@@ -215,8 +263,12 @@ void VideoCtl::stream_component_close(VideoState *is, int stream_index)
 
     switch (codecpar->codec_type) {
     case AVMEDIA_TYPE_AUDIO:
+        if (audio_dev) {
+            SDL_PauseAudioDevice(audio_dev, 1);
+            SDL_CloseAudioDevice(audio_dev);
+            audio_dev = 0;
+        }
         decoder_abort(&is->auddec, &is->sampq);
-        SDL_CloseAudio();
         decoder_destroy(&is->auddec);
         swr_free(&is->swr_ctx);
         av_freep(&is->audio_buf1);
@@ -407,6 +459,14 @@ void VideoCtl::stream_seek(VideoState *is, int64_t pos, int64_t rel)
         is->seek_rel = rel;
         is->seek_flags &= ~AVSEEK_FLAG_BYTE;
         is->seek_req = 1;
+        is->force_refresh = 1;
+        SDL_CondSignal(is->continue_read_thread);
+    } else {
+        // Overwrite pending seek so the latest user action wins.
+        is->seek_pos = pos;
+        is->seek_rel = rel;
+        is->seek_flags &= ~AVSEEK_FLAG_BYTE;
+        is->force_refresh = 1;
         SDL_CondSignal(is->continue_read_thread);
     }
 }
@@ -990,8 +1050,16 @@ void sdl_audio_callback(void *opaque, Uint8 *stream, int len)
             memcpy(stream, (uint8_t *)is->audio_buf + is->audio_buf_index, len1);
         else {
             memset(stream, 0, len1);
-            if (is->audio_buf)
-                SDL_MixAudio(stream, (uint8_t *)is->audio_buf + is->audio_buf_index, len1, is->audio_volume);
+            if (is->audio_buf) {
+                int16_t *dst = (int16_t *)stream;
+                int16_t *src = (int16_t *)((uint8_t *)is->audio_buf + is->audio_buf_index);
+                int samples = len1 / sizeof(int16_t);
+                int volume = is->audio_volume;
+                for (int i = 0; i < samples; ++i) {
+                    int v = (int)src[i] * volume / SDL_MIX_MAXVOLUME;
+                    dst[i] = (int16_t)av_clip(v, -32768, 32767);
+                }
+            }
         }
         len -= len1;
         stream += len1;
@@ -1710,18 +1778,38 @@ the_end:
     stream_component_open(is, stream_index);
 }
 
+int VideoCtl::pump_events(SDL_Event *event)
+{
+#if defined(__APPLE__)
+    int num_events = 0;
+    if (QThread::currentThread() == this->thread()) {
+        SDL_PumpEvents();
+        num_events = SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
+    } else {
+        QMetaObject::invokeMethod(this, [this, event, &num_events]() {
+            SDL_PumpEvents();
+            num_events = SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
+        }, Qt::BlockingQueuedConnection);
+    }
+    return num_events;
+#else
+    SDL_PumpEvents();
+    return SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT);
+#endif
+}
+
 
 void VideoCtl::refresh_loop_wait_event(VideoState *is, SDL_Event *event) {
     double remaining_time = 0.0;
-    SDL_PumpEvents();
-    while (!SDL_PeepEvents(event, 1, SDL_GETEVENT, SDL_FIRSTEVENT, SDL_LASTEVENT) && m_bPlayLoop)
+    int got_event = pump_events(event);
+    while (!got_event && m_bPlayLoop)
     {
         if (remaining_time > 0.0)
             av_usleep((int64_t)(remaining_time * 1000000.0));
         remaining_time = REFRESH_RATE;
         if (!is->paused || is->force_refresh)
             video_refresh(is, &remaining_time);
-        SDL_PumpEvents();
+        got_event = pump_events(event);
     }
 }
 
@@ -1814,6 +1902,16 @@ void VideoCtl::LoopThread(VideoState *cur_stream)
 
 }
 
+void VideoCtl::OnRefreshTick()
+{
+    QMutexLocker locker(&m_playMutex);
+    if (!m_bPlayLoop || m_CurStream == nullptr)
+        return;
+
+    double remaining_time = 0.0;
+    video_refresh(m_CurStream, &remaining_time);
+}
+
 
 void VideoCtl::OnPlaySeek(double dPercent)
 {
@@ -1821,7 +1919,19 @@ void VideoCtl::OnPlaySeek(double dPercent)
     {
         return;
     }
-    int64_t ts = dPercent * m_CurStream->ic->duration;
+    double percent = dPercent;
+    if (percent < 0.0)
+        percent = 0.0;
+    if (percent > 1.0)
+        percent = 1.0;
+    int64_t ts = percent * m_CurStream->ic->duration;
+    if (m_CurStream->ic->duration > 0) {
+        int64_t max_ts = m_CurStream->ic->duration;
+        if (max_ts > static_cast<int64_t>(0.1 * AV_TIME_BASE))
+            max_ts -= static_cast<int64_t>(0.1 * AV_TIME_BASE);
+        if (ts > max_ts)
+            ts = max_ts;
+    }
     if (m_CurStream->ic->start_time != AV_NOPTS_VALUE)
         ts += m_CurStream->ic->start_time;
     stream_seek(m_CurStream, ts, 0);
@@ -1829,12 +1939,22 @@ void VideoCtl::OnPlaySeek(double dPercent)
 
 void VideoCtl::OnPlayVolume(double dPercent)
 {
-    startup_volume = dPercent * SDL_MIX_MAXVOLUME;
+    if (dPercent < 0.0)
+        dPercent = 0.0;
+    if (dPercent > 1.0)
+        dPercent = 1.0;
+    double gain = sqrt(dPercent);
+    int volume_percent = lrint(gain * 100.0);
+    volume_percent = av_clip(volume_percent, 0, 100);
+    startup_volume = volume_percent;
     if (m_CurStream == nullptr)
     {
         return;
     }
-    m_CurStream->audio_volume = startup_volume;
+    int vol = av_clip(SDL_MIX_MAXVOLUME * volume_percent / 100, 0, SDL_MIX_MAXVOLUME);
+    if (dPercent > 0.0 && vol == 0)
+        vol = 1;
+    m_CurStream->audio_volume = vol;
 }
 
 void VideoCtl::OnSeekForward()
@@ -1848,6 +1968,15 @@ void VideoCtl::OnSeekForward()
     if (std::isnan(pos))
         pos = (double)m_CurStream->seek_pos / AV_TIME_BASE;
     pos += incr;
+    if (m_CurStream->ic->duration > 0) {
+        double max_pos = m_CurStream->ic->duration / (double)AV_TIME_BASE;
+        if (max_pos > 0.1)
+            max_pos -= 0.1;
+        if (m_CurStream->ic->start_time != AV_NOPTS_VALUE)
+            max_pos += m_CurStream->ic->start_time / (double)AV_TIME_BASE;
+        if (pos > max_pos)
+            pos = max_pos;
+    }
     if (m_CurStream->ic->start_time != AV_NOPTS_VALUE && pos < m_CurStream->ic->start_time / (double)AV_TIME_BASE)
         pos = m_CurStream->ic->start_time / (double)AV_TIME_BASE;
     stream_seek(m_CurStream, (int64_t)(pos * AV_TIME_BASE), (int64_t)(incr * AV_TIME_BASE));
@@ -1885,6 +2014,10 @@ void VideoCtl::UpdateVolume(int sign, double step)
 /* display the current picture, if any */
 void VideoCtl::video_display(VideoState *is)
 {
+#if defined(__APPLE__)
+    video_image_display(is);
+    return;
+#endif
     if (!window)
         video_open(is);
     if (renderer)
@@ -1948,6 +2081,14 @@ int VideoCtl::video_open(VideoState *is)
 
 void VideoCtl::do_exit(VideoState* &is)
 {
+#if defined(__APPLE__)
+    if (QThread::currentThread() != this->thread()) {
+        QMetaObject::invokeMethod(this, [this, &is]() { do_exit(is); }, Qt::BlockingQueuedConnection);
+        return;
+    }
+    if (m_refreshTimer.isActive())
+        m_refreshTimer.stop();
+#endif
     if (is)
     {
         stream_close(is);
@@ -1961,7 +2102,7 @@ void VideoCtl::do_exit(VideoState* &is)
 
     if (window)
     {
-        //SDL_DestroyWindow(window);
+        SDL_DestroyWindow(window);
         window = nullptr;
     }
 
@@ -1998,7 +2139,20 @@ void VideoCtl::OnPause()
 
 void VideoCtl::OnStop()
 {
+#if defined(__APPLE__)
+    if (QThread::currentThread() != this->thread()) {
+        QMetaObject::invokeMethod(this, [this]() { OnStop(); }, Qt::BlockingQueuedConnection);
+        return;
+    }
+#endif
+    QMutexLocker locker(&m_playMutex);
     m_bPlayLoop = false;
+#if defined(__APPLE__)
+    if (m_refreshTimer.isActive())
+        m_refreshTimer.stop();
+#endif
+    if (m_CurStream)
+        do_exit(m_CurStream);
 }
 
 VideoCtl::VideoCtl(QObject *parent) :
@@ -2011,12 +2165,18 @@ screen_height(0),
 startup_volume(30),
 renderer(nullptr),
 window(nullptr),
+audio_dev(0),
 m_nFrameW(0),
 m_nFrameH(0)
 {
     avdevice_register_all();
     //网络格式初始化
     avformat_network_init();
+
+#if defined(__APPLE__)
+    m_refreshTimer.setInterval(static_cast<int>(REFRESH_RATE * 1000));
+    connect(&m_refreshTimer, &QTimer::timeout, this, &VideoCtl::OnRefreshTick);
+#endif
 }
 
 bool VideoCtl::Init()
@@ -2047,7 +2207,7 @@ bool VideoCtl::Init()
 
 bool VideoCtl::ConnectSignalSlots()
 {
-    connect(this, &VideoCtl::SigStop, &VideoCtl::OnStop);
+    connect(this, &VideoCtl::SigStop, this, &VideoCtl::OnStop, Qt::QueuedConnection);
 
     return true;
 }
@@ -2074,7 +2234,14 @@ VideoCtl::~VideoCtl()
 
 bool VideoCtl::StartPlay(QString strFileName, WId widPlayWid)
 {
-    m_bPlayLoop = false;
+    {
+        QMutexLocker locker(&m_playMutex);
+        m_bPlayLoop = false;
+#if defined(__APPLE__)
+        if (m_refreshTimer.isActive())
+            m_refreshTimer.stop();
+#endif
+    }
     if (m_tPlayLoopThread.joinable())
     {
         m_tPlayLoopThread.join();
@@ -2095,10 +2262,22 @@ bool VideoCtl::StartPlay(QString strFileName, WId widPlayWid)
         do_exit(m_CurStream);
     }
 
-    m_CurStream = is;
+    {
+        QMutexLocker locker(&m_playMutex);
+        m_CurStream = is;
+    }
 
     //事件循环
+#if defined(__APPLE__)
+    {
+        QMutexLocker locker(&m_playMutex);
+        m_bPlayLoop = true;
+        if (!m_refreshTimer.isActive())
+            m_refreshTimer.start();
+    }
+#else
     m_tPlayLoopThread = std::thread(&VideoCtl::LoopThread, this, is);
+#endif
 
 
     return true;

--- a/src/videoctl.h
+++ b/src/videoctl.h
@@ -13,7 +13,10 @@
 
 #include <QObject>
 #include <QThread>
+#include <QTimer>
 #include <QString>
+#include <QImage>
+#include <QMutex>
 
 #include "globalhelper.h"
 #include "datactl.h"
@@ -48,6 +51,7 @@ public:
 signals:
     void SigPlayMsg(QString strMsg);//< 错误信息
     void SigFrameDimensionsChanged(int nFrameWidth, int nFrameHeight); //<视频宽高发生变化
+    void SigVideoFrame(const QImage &frame);
 
     void SigVideoTotalSeconds(int nSeconds);
     void SigVideoPlaySeconds(int nSeconds);
@@ -104,6 +108,7 @@ private:
     VideoState *stream_open(const char *filename);
 
     void stream_cycle_channel(VideoState *is, int codec_type);
+    int pump_events(SDL_Event *event);
     void refresh_loop_wait_event(VideoState *is, SDL_Event *event);
     void seek_chapter(VideoState *is, int incr);
     void video_refresh(void *opaque, double *remaining_time);
@@ -118,6 +123,7 @@ private:
     int realloc_texture(SDL_Texture **texture, Uint32 new_format, int new_width, int new_height, SDL_BlendMode blendmode, int init_texture);
     void calculate_display_rect(SDL_Rect *rect, int scr_xleft, int scr_ytop, int scr_width, int scr_height, int pic_width, int pic_height, AVRational pic_sar);
     int upload_texture(SDL_Texture *tex, AVFrame *frame, struct SwsContext **img_convert_ctx);
+    QImage frame_to_image(AVFrame *frame, struct SwsContext **img_convert_ctx);
     void video_image_display(VideoState *is);
     void stream_component_close(VideoState *is, int stream_index);
     void stream_close(VideoState *is);
@@ -137,6 +143,7 @@ private:
     double compute_target_delay(double delay, VideoState *is);
     double vp_duration(VideoState *is, Frame *vp, Frame *nextvp);
     void update_video_pts(VideoState *is, double pts, int64_t pos, int serial);
+    void OnRefreshTick();
 public:
 
 
@@ -163,9 +170,12 @@ private:
 
     //播放刷新循环线程
     std::thread m_tPlayLoopThread;
+    QTimer m_refreshTimer;
 
     int m_nFrameW;
     int m_nFrameH;
+
+    QMutex m_playMutex;
 };
 
 #endif // VIDEOCTL_H


### PR DESCRIPTION
# 修改汇总

本文档总结了为修复 macOS 播放崩溃、UI 覆盖、音量异常等问题所做的改动。

## 功能层面变化
- macOS 下视频渲染改为 Qt（`QImage` + `QPainter`），不再依赖 SDL 窗口嵌入，避免 UI 被覆盖与播放结束黑屏卡住。
- macOS 播放刷新由主线程 `QTimer` 驱动，避免 SDL 事件泵在非主线程导致崩溃。
- 音频设备关闭方式改为 `SDL_CloseAudioDevice`，避免回调使用已释放内存引发崩溃。
- 音量控制改为手动 PCM 缩放并使用感知更均匀的曲线，非最大音量也能正常听到声音。

## 按模块/文件的改动

### 视频渲染（macOS）
- `VideoCtl` 每帧发出 `SigVideoFrame(QImage)`；`Show` 在 `paintEvent` 中按比例绘制。
- macOS 下绕过 SDL 窗口/renderer，避免嵌入窗口造成 UI 覆盖。

涉及文件：
- `src/videoctl.h`（新增信号、`QImage` 相关声明）
- `src/videoctl.cpp`（帧转换、mac 分支显示逻辑）
- `src/show.h` / `src/show.cpp`（帧缓存、绘制与等比缩放）
- `src/mainwid.cpp`（连接 `SigVideoFrame` 到 `Show::OnVideoFrame`）

### 线程/生命周期安全
- 新增 `m_playMutex`，确保 `m_CurStream` 在刷新与释放间不会并发访问。
- `OnRefreshTick / OnStop / StartPlay` 增加锁保护，减少竞态导致的崩溃。
- `OnStop` 在 macOS 下执行完整清理，确保 UI 和资源恢复。

涉及文件：
- `src/videoctl.h`
- `src/videoctl.cpp`

### 音频稳定性
- 音频关闭由 `SDL_CloseAudio` 改为 `SDL_CloseAudioDevice` + `SDL_PauseAudioDevice`。
- 用手动 PCM 缩放代替 `SDL_MixAudio`，保证音量可控且跨平台一致。

涉及文件：
- `src/videoctl.cpp`

### Seek/音量行为调整
- Seek 支持“最新操作覆盖”，并对越界 seek 做限制与纠正。
- 音量映射使用 `sqrt` 曲线，并确保非 0 音量不会被舍入为 0。

涉及文件：
- `src/videoctl.cpp`

## 备注
- `sws` 的软件转换日志（`No accelerated colorspace conversion...`）为正常提示。
- macOS 专用逻辑均用宏条件编译，其它平台保持原有 SDL 渲染路径。