### PR TITLE
fix(mainwid): 修正项目编译失败

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 https://itisyang.github.io/playerdemo/
 
 ## 简介
-- 使用 FFmpeg-3.4 (x64) 解码，SDL2-2.0.7 (x64) 渲染。  
+- 使用 FFmpeg-5.1 (x64) 解码，SDL2-2.0.7 (x64) 渲染。  
 - 在 Windows 下使用 Qt5.12.x (MinGW x64) 开发。  
 - 项目目录下的 .pro 文件，支持在多平台（Windows、Linux、Mac）下 QtCreator 打开编译调试。  
 

--- a/src/mainwid.cpp
+++ b/src/mainwid.cpp
@@ -317,7 +317,7 @@ void MainWid::OnFullScreenPlay()
         //脱离父窗口后才能设置
         ui->ShowWid->setWindowFlags(Qt::Window);
         //多屏情况下，在当前屏幕全屏
-        QScreen *pStCurScreen = screen();
+        QScreen *pStCurScreen = windowHandle()->screen();
         ui->ShowWid->windowHandle()->setScreen(pStCurScreen);
         
         ui->ShowWid->showFullScreen();


### PR DESCRIPTION
## 运行环境

- Qt 5.12.12
- MinGW 7.3.0 64-bit
- FFmpeg 5.1
- SDL2

## 修复内容

### 1. 修复 Qt5 低版本编译失败：`screen()` 未声明

**错误信息：**
```
mainwid.cpp:320:33: error: 'screen' was not declared in this scope
        QScreen *pStCurScreen = screen();
```

**截图：**

<img width="1129" height="650" alt="1error" src="https://github.com/user-attachments/assets/8578c6d2-1c92-4da0-8222-5ef5091d2ce5" />

**原因：** `QWidget::screen()` 是 Qt 5.14 才引入的方法，项目要求的 Qt 5.12.x 不支持该 API。

**修复：** 改用 `windowHandle()->screen()`，功能等价且兼容所有 Qt5 版本。

```diff
- QScreen *pStCurScreen = screen();
+ QScreen *pStCurScreen = windowHandle()->screen();
```



### 2. 修复 README 中 FFmpeg 版本号错误

**问题：** README 中标注 FFmpeg 版本为 3.4，但项目实际依赖 FFmpeg 5.1（avcodec-59）。使用 FFmpeg 4.x 的 DLL 运行时会报错找不到 `avcodec-59.dll`。

**截图：**

<img width="766" height="654" alt="2error" src="https://github.com/user-attachments/assets/8aa1961b-4638-4c6b-a57d-1762a9c97fea" />


**修复：** 将 README 中的版本号更正为 `FFmpeg-5.1`。

```diff
-- 使用 FFmpeg-3.4 (x64) 解码，SDL2-2.0.7 (x64) 渲染。
+- 使用 FFmpeg-5.1 (x64) 解码，SDL2-2.0.7 (x64) 渲染。
```
