### PR TITLE
fix: 修复全屏播放后 PlaylistWid 文本渲染到视频画面上

### DIFF
--- a/src/mainwid.cpp
+++ b/src/mainwid.cpp
@@ -312,6 +312,8 @@ void MainWid::OnFullScreenPlay()
 {
     if (m_bFullScreenPlay == false)
     {
+        // 全屏前隐藏 PlaylistWid，避免它留在旧位置被渲染到视频画面上
+        ui->PlaylistWid->hide();
         m_bFullScreenPlay = true;
         m_stActFullscreen.setChecked(true);
         //脱离父窗口后才能设置
@@ -364,6 +366,8 @@ void MainWid::OnFullScreenPlay()
 
         ui->CtrlBarWid->showNormal();
         ui->ShowWid->showNormal();
+        // 退出全屏时显示 PlaylistWid
+        ui->PlaylistWid->show();
 
         m_stFullscreenMouseDetectTimer.stop();
         this->setFocus();


### PR DESCRIPTION
## 运行环境
+ Qt 5.12.12
+ MinGW 7.3.0 64-bit
+ FFmpeg 5.1
+ SDL2

## 修复内容
### 1. 修复全屏播放后 PlaylistWid 文本渲染到视频画面上
**问题：** 窗口宽度被拉伸到很小时，进入全屏播放，然后恢复正常窗口大小时，视频画面右侧会出现 PlaylistWid 的文本汉字，干扰视频显示。

**原因：** 全屏时 ShowWid 被设置为顶层窗口脱离 MainWindow，MainWindow 不再包含 ShowWid 的区域，PlaylistWid 失去右侧约束后向左挤压，显示到了 ShowWid 原本应占用的区域，导致其文本被渲染到视频画面上。全屏状态下该渲染被视频遮挡不可见，恢复正常窗口后即可看到 ShowWid 右侧多出了 PlaylistWid 的文本。

**修复：** 进入全屏时隐藏 PlaylistWid，退出全屏时恢复显示，避免其挤占 ShowWid 区域。

```diff
 void MainWid::OnFullScreenPlay()
 {
     if (m_bFullScreenPlay == false)
     {
+        // 全屏前隐藏 PlaylistWid，避免它留在旧位置被渲染到视频画面上
+        ui->PlaylistWid->hide();
         m_bFullScreenPlay = true;
         ...
     }
     else
     {
         ...
         ui->CtrlBarWid->showNormal();
         ui->ShowWid->showNormal();
+        // 退出全屏时显示 PlaylistWid
+        ui->PlaylistWid->show();

         m_stFullscreenMouseDetectTimer.stop();
         this->setFocus();
     }
 }
```

**截图：**

正常窗口 → 全屏 → 恢复正常窗口：

<img src="https://cdn.nlark.com/yuque/0/2026/png/1270500/1780112377321-f95824fb-a2d9-4825-8168-8d43a2f49ea2.png" width="800" title="" crop="0,0,1,1" id="GjoFR" class="ne-image">

窗口被拉伸变窄后 → 全屏 → 恢复正常窗口（右侧出现 PlaylistWid 文本）：

<img src="https://cdn.nlark.com/yuque/0/2026/png/1270500/1780112390225-027dd4f5-0415-42a5-b412-5f1a7030a7bd.png" width="420" title="" crop="0,0,1,1" id="JmLBD" class="ne-image">




